### PR TITLE
Fix local admins not being able to see stats for groups they are not a member of but have created.

### DIFF
--- a/db/user.py
+++ b/db/user.py
@@ -224,7 +224,6 @@ def users_statistics(
                 group = (
                     session.query(Group)
                     .filter(Group.id == group_id)
-                    .filter(Group.users.any(User.user_id == user_id))
                     .first()
                 )
 


### PR DESCRIPTION
* remove criteria that user is part of group when fetching