### PR TITLE
changed error to warning so external status polling won't produce errors

### DIFF
--- a/auth/oidc.py
+++ b/auth/oidc.py
@@ -197,7 +197,7 @@ async def verify_user(request: Request, admin: Optional[bool] = False) -> str:
 
     # Check if the user is active
     if not user["active"]:
-        log.error(f"User {user_id} is not active.")
+        log.info(f"User {user_id} is not active.")
         raise HTTPException(status_code=403, detail="User is not active.")
 
     if admin and not user["admin"]:

--- a/routers/external.py
+++ b/routers/external.py
@@ -81,7 +81,7 @@ async def get_job_external(
         )
 
     if not (job_result := await job_result_get_external(external_id)):
-        logger.error(f"External job result not found: {external_id}")
+        logger.warning(f"External job result not found: {external_id}")
         return JSONResponse(
             content={
                 "result": res


### PR DESCRIPTION
Kaltura fetcher tries to pull the completed job every minute. This produces an error everytime the job is pending or otherwise not complete.

This is to produce a warning instead which won't echo through monitoring.