### PR TITLE
store rotated refresh token

### DIFF
--- a/app.py
+++ b/app.py
@@ -376,7 +376,6 @@ async def refresh(request: Request, refresh_token: RefreshToken):
     Returns:
         JSONResponse: The new access token.
     """
-
     data = {
         "client_id": settings.OIDC_CLIENT_ID,
         "client_secret": settings.OIDC_CLIENT_SECRET,
@@ -394,7 +393,16 @@ async def refresh(request: Request, refresh_token: RefreshToken):
     except Exception:
         return JSONResponse({"error": "Failed to refresh token"}, status_code=400)
 
-    return JSONResponse({"access_token": response.json()["access_token"]})
+    token_response = response.json()
+
+    payload = {
+        "access_token": token_response["access_token"],
+    }
+
+    if token_response.get("refresh_token"):
+        payload["refresh_token"] = token_response["refresh_token"]
+
+    return JSONResponse(payload)
 
 
 @app.get("/api/docs")


### PR DESCRIPTION
Support refresh token rotation during OIDC token refresh

Return refresh_token from the refresh endpoint when supplied by the OIDC
provider, and update the stored user refresh token on the client side.
This keeps the app compatible with providers that rotate refresh tokens
and invalidate the previous token after use.

This resolves an issue where users were getting logged out because they would use an old refresh token.